### PR TITLE
Don't skip reset if platform data has changed

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2997,7 +2997,8 @@ namespace bgfx
 		{
 			const TextureFormat::Enum format = TextureFormat::Count != _format ? _format : m_init.resolution.format;
 
-			if (m_init.resolution.format == format
+			if (!g_platformDataChangedSinceReset
+			&&  m_init.resolution.format == format
 			&&  m_init.resolution.width  == _width
 			&&  m_init.resolution.height == _height
 			&&  m_init.resolution.reset  == _flags)


### PR DESCRIPTION
This check was recently added to not resize textures if the resolution and format have not changed when calling reset, however we need to also honor the scenario where the platform data has changed since the last reset occurred.

We already have a flag g_platformDataChangedSinceReset to handle this scenario, but was skipped during this initial condition check.  Adding this check back so that we properly prepare textures when the window pointer changes.