### PR TITLE
Reset s_renderFrameCalled on bgfx::shutdown

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -3562,9 +3562,10 @@ namespace bgfx
 			s_allocatorStub = NULL;
 		}
 
-		s_threadIndex = 0;
-		g_callback    = NULL;
-		g_allocator   = NULL;
+		s_threadIndex       = 0;
+		s_renderFrameCalled = false;
+		g_callback          = NULL;
+		g_allocator         = NULL;
 	}
 
 	void reset(uint32_t _width, uint32_t _height, uint32_t _flags, TextureFormat::Enum _format)


### PR DESCRIPTION
Without this, it is impossible to get `m_singleThreaded` to be `true` after a `bgfx::shutdown`.