### PR TITLE
Fix vertex buffer type encoding for Int16, Uint16, Half and Float

### DIFF
--- a/src/vertexlayout.cpp
+++ b/src/vertexlayout.cpp
@@ -102,7 +102,7 @@ namespace bgfx
 		const uint16_t encodedNorm = (_normalized&1)<<7;
 		const uint16_t encodedType = (_type&7)<<3;
 		const uint16_t encodedNum  = (_num-1)&3;
-		const uint16_t encodeAsInt = (_asInt&(!!"\x1\x1\x1\x0\x0"[_type]) )<<8;
+		const uint16_t encodeAsInt = (_asInt&(!!"\x1\x1\x1\x1\x1\x0\x0"[_type]) )<<8;
 		m_attributes[_attrib] = encodedNorm|encodedType|encodedNum|encodeAsInt;
 
 		m_offset[_attrib] = m_stride;


### PR DESCRIPTION
In my last PR #16 I added support for Uint16 and Int8 buffer types, but did not update the string used to determine whether we should encode the value as an int in VertexLayout::add to account for this.  This PR adds these missing entries to prevent buffer overflows when adding these buffers so they can be properly decoded.