### PR TITLE
Expose Metal command queue

### DIFF
--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -580,6 +580,7 @@ typedef struct bgfx_internal_data_s
 {
     const bgfx_caps_t*   caps;               /** Renderer capabilities.                   */
     void*                context;            /** GL context, or D3D device.               */
+    void*                commandQueue;       /** Metal command queue, or NULL.     */
 
 } bgfx_internal_data_t;
 

--- a/include/bgfx/platform.h
+++ b/include/bgfx/platform.h
@@ -67,7 +67,7 @@ namespace bgfx
 	{
 		const struct Caps* caps; //!< Renderer capabilities.
 		void* context;           //!< GL context, or D3D device.
-        void* commandQueue;      //!< Metal command queue, or NULL.
+		void* commandQueue;      //!< Metal command queue, or NULL.
 	};
 
 	/// Get internal data for interop.

--- a/include/bgfx/platform.h
+++ b/include/bgfx/platform.h
@@ -67,6 +67,7 @@ namespace bgfx
 	{
 		const struct Caps* caps; //!< Renderer capabilities.
 		void* context;           //!< GL context, or D3D device.
+        void* commandQueue;      //!< Metal command queue, or NULL.
 	};
 
 	/// Get internal data for interop.

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3419,7 +3419,7 @@ namespace bgfx { namespace mtl
 	void CommandQueueMtl::init(Device _device)
 	{
 		m_commandQueue = _device.newCommandQueue();
-        g_internalData.commandQueue = m_commandQueue.m_obj;
+		g_internalData.commandQueue = m_commandQueue.m_obj;
 		m_framesSemaphore.post(MTL_MAX_FRAMES_IN_FLIGHT);
 	}
 

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3419,6 +3419,7 @@ namespace bgfx { namespace mtl
 	void CommandQueueMtl::init(Device _device)
 	{
 		m_commandQueue = _device.newCommandQueue();
+        g_internalData.commandQueue = m_commandQueue.m_obj;
 		m_framesSemaphore.post(MTL_MAX_FRAMES_IN_FLIGHT);
 	}
 


### PR DESCRIPTION
For Babylon Native ARKit integration, we do the following:
1. Get the camera texture from ARKit and draw a portion of it to a render texture
2. Have bgfx render to the render texture
3. Draw the render texture to the screen

These operations need to be synchronized, and the most robust way to do this seems to be to use the same command queue that bgfx is using. Therefore, expose the command queue. We probably need further discussion regarding a longer term solution for this that isn't platform specific.