### PR TITLE
Sync renderer_mtl.mm with upstream version

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -649,14 +649,11 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 					{
 						g_caps.vendorId = BGFX_PCI_ID_APPLE;
 
-#if ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 130000) || (__IPHONE_OS_VERSION_MAX_ALLOWED >= 160000))
 						if ([m_device supportsFamily: MTLGPUFamilyApple8])
 						{
 							g_caps.deviceId = 1008;
 						}
-						else
-#endif
-						if ([m_device supportsFamily: MTLGPUFamilyApple7])
+						else if ([m_device supportsFamily: MTLGPUFamilyApple7])
 						{
 							g_caps.deviceId = 1007;
 						}


### PR DESCRIPTION
To get the build working on older version of Xcode, I created [PR #35](https://github.com/BabylonJS/bgfx/pull/35), but I was not able to get it merged upstream, so our fork diverged a bit.

The upstream version has since been updated to support older builds of Xcode in an unrelated PR, so this change syncs those changes back into our fork.