### PR TITLE
DX12: fix invalid state when creating a BLIT_DST texture without mem …

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -5883,6 +5883,10 @@ namespace bgfx { namespace d3d12
 
 				s_renderD3D12->m_cmd.release(staging);
 			}
+			else if (0 == _external)
+			{
+				setState(commandList, state);
+			}
 
 			if (0 != kk)
 			{


### PR DESCRIPTION
…block (#3656)

* DX12: fix invalid state when creating a BLIT_DST texture without mem block

* Only set state when it's not external texture.

---------