### PR TITLE
Fix UBSan undefined-behavior hits in bgfx_p.h (cherry-pick of bkaradzic/bgfx#3688)

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -849,18 +849,22 @@ namespace bgfx
 	struct BitMaskToIndexIteratorT
 	{
 		BitMaskToIndexIteratorT(MaskT _mask)
+			: mask(0)
+			, idx(0)
 		{
-			const uint8_t ntz = bx::countTrailingZeros(_mask);
-			mask = _mask >> ntz;
+			const uint8_t ntz = bx::countTrailingZeros<MaskT>(_mask);
+			mask = 0 == _mask ? MaskT(0) : MaskT(_mask >> ntz);
 			idx  = ntz;
 		}
 
 		void next()
 		{
-			// operator>> promotes to int, so we need to cast back:
-			const uint8_t ntzPlus1 = bx::countTrailingZeros<MaskT>(mask>>1) + 1;
-			mask >>= ntzPlus1;
-			idx   += ntzPlus1;
+			mask = MaskT(mask >> 1);
+			idx += 1;
+
+			const uint8_t ntz = bx::countTrailingZeros<MaskT>(mask);
+			mask = 0 == mask ? MaskT(0) : MaskT(mask >> ntz);
+			idx += ntz;
 		}
 
 		bool isDone() const
@@ -2749,6 +2753,7 @@ namespace bgfx
 			// clear all bytes (inclusively the padding) before we start.
 			bx::memSet(&m_bind, 0, sizeof(m_bind) );
 
+			m_key.reset();
 			m_discard = false;
 			m_draw.clear(BGFX_DISCARD_ALL);
 			m_compute.clear(BGFX_DISCARD_ALL);


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

Cherry-picks the upstream UBSan fix from [bkaradzic/bgfx#3688](https://github.com/bkaradzic/bgfx/pull/3688) (merged commit [`ac54f48d`](https://github.com/bkaradzic/bgfx/commit/ac54f48d4dc4d40cc6265574b2c0576c613bc79e)) onto `BabylonJS/bgfx:update-bgfx`.

## What this fixes

Two distinct UB hits in `src/bgfx_p.h` that surface only under `-fno-sanitize-recover=all` UBSan (i.e. when sanitizer findings are made fatal):

1. **`SortKey` uninitialized `bool` read.** `SortKey` had no default initializers — initialization happened only via `reset()`. `EncoderImpl` constructed an embedded `m_key` whose `m_hasAlphaRef` was then read by `encodeDraw()` before `reset()` ran, producing `'load of value 190, which is not a valid value for type bool'`. Fix: call `m_key.reset()` as the first thing in `EncoderImpl()`. Narrower than default-initializing the type because all other `SortKey` consumers always `decode(...)` before reading.

2. **`BitMaskToIndexIteratorT` shift-by-width.** `bx::countTrailingZeros(0)` returns the type width, which was then used as a shift exponent — UB for the zero-mask case. Fix: branchless ternary `mask = (0 == _mask) ? 0 : _mask >> ntz;` in both the constructor and `next()`. Behavior preserved (`isDone()` returns true on the same iterations as before).

## Validation

Verified end-to-end via temporary repoint of [BN #1676](https://github.com/BabylonJS/BabylonNative/pull/1676) (`MacOS_Sanitizers` job runs UBSan with `halt_on_error=1`):

- Pre-fix: `MacOS_Sanitizers` failed with both findings.
- Post-fix (this commit): full BN pipeline green, including `MacOS_Sanitizers` (28✅).

## Cherry-pick provenance

Single squash commit copied via `git cherry-pick -x` from upstream merge `ac54f48d`. Diff is identical to the upstream squash. Standard `(cherry picked from commit …)` footer included.

## Follow-ups (separate PRs)

After this merges:
1. Bump the `bgfx` submodule pointer on `BabylonJS/bgfx.cmake` to the merge commit of this PR.
2. Bump `bgfx.cmake` `GIT_TAG` in BabylonNative `CMakeLists.txt` to that bgfx.cmake bump SHA (replaces the temporary `bghgary/bgfx.cmake` validation pin currently on BN #1676).
