### PR TITLE
renderer_gl: support external textures (BGFX_CAPS_TEXTURE_EXTERNAL)

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2930,6 +2930,11 @@ namespace bgfx { namespace gl
 					: 0
 					;
 
+				// External textures are imported by wrapping an existing GL texture
+				// id (see createTexture/TextureGL::overrideInternal), which is valid
+				// on any GL/GLES context, so the capability is always advertised.
+				g_caps.supported |= BGFX_CAPS_TEXTURE_EXTERNAL;
+
 				g_caps.supported |= false
 					|| s_extension[Extension::EXT_texture_array].m_supported
 					|| s_extension[Extension::EXT_gpu_shader4].m_supported
@@ -3429,8 +3434,18 @@ namespace bgfx { namespace gl
 
 		void* createTexture(TextureHandle _handle, const Memory* _mem, uint64_t _flags, uint8_t _skip, uint64_t _external) override
 		{
-			BX_UNUSED(_external);
-			m_textures[_handle.idx].create(_mem, _flags, _skip);
+			TextureGL& texture = m_textures[_handle.idx];
+			texture.create(_mem, _flags, _skip);
+
+			// When an external native handle is supplied, replace the freshly
+			// allocated GL texture with the caller-owned texture id. overrideInternal
+			// sets BGFX_SAMPLER_INTERNAL_SHARED so TextureGL::destroy will not delete
+			// the externally owned id.
+			if (0 != _external)
+			{
+				texture.overrideInternal(uintptr_t(_external) );
+			}
+
 			return NULL;
 		}
 


### PR DESCRIPTION
## What

Add OpenGL/OpenGL ES support for bgfx external textures (importing an existing, caller-owned GL texture id instead of allocating a new one).

Two changes in `src/renderer_gl.cpp`:

1. **Advertise `BGFX_CAPS_TEXTURE_EXTERNAL`.** The GL renderer never set this capability, so `createTexture2D(..., _external)` tripped the `"External texture is not supported!"` assertion in `bgfx.cpp`. The D3D11, D3D12, Metal, and Vulkan renderers already advertise it.
2. **Honor the `_external` handle in `createTexture`.** The override previously did `BX_UNUSED(_external)` and always allocated a fresh texture. It now adopts the supplied id via the existing `TextureGL::overrideInternal`, which sets `BGFX_SAMPLER_INTERNAL_SHARED` so `TextureGL::destroy` will not delete the externally owned texture.

## Why

This is the renderer-side counterpart required by BabylonNative's ExternalTexture OpenGL backend (BabylonJS/BabylonNative#1780). Without it, the OpenGL/OpenGL ES path fatals at runtime with `External texture is not supported!` because the GL renderer neither advertises the capability nor wraps the provided texture id.

Importing an existing GL texture id is valid on any GL/GLES context, so the capability is advertised unconditionally, matching the other backends.